### PR TITLE
Fix flood in log

### DIFF
--- a/src/Classes/MonsterHunt.uc
+++ b/src/Classes/MonsterHunt.uc
@@ -818,4 +818,5 @@ defaultproperties {
 	GameReplicationInfoClass=Class'{{package}}.MonsterReplicationInfo'
 	bLocalLog=True
 	DefaultBotOrders='Attack'
+	bScoreTeamKills=False
 }


### PR DESCRIPTION
`Error: MonsterHunt Autoplay.MonsterHunt0 (Function Botpack.TeamGamePlus.ScoreKill:016E) Accessed array 'Teams' out of bounds (255/4)`